### PR TITLE
Corrected value returned by tempfile_app:start/1 (tuple instead of "ok")

### DIFF
--- a/src/tempfile_app.erl
+++ b/src/tempfile_app.erl
@@ -13,7 +13,7 @@
 
 start(_Type, _Args) ->
   _ = random:seed(erlang:system_time(micro_seconds)),
-  ok.
+  {ok,self()}.
 
 stop(_State) ->
   ok.


### PR DESCRIPTION
Corrected value returned by tempfile_app:start/1 (tuple instead of "ok")
